### PR TITLE
Solution 4 - Largest Palindrome of 2 x 3-digit number products

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -7,7 +7,7 @@ For #
   When an item is complete, then go ahead and check it off as "done", e.g.:
     - [x] A description of the changes proposed in the pull request.
 -->
-_Please include:_
+Please include:
 - [ ] _A reference to a related issue in your repository._
 - [ ] _A description of the changes proposed in the pull request._
 - [ ] _`@mentions of the person or team responsible for reviewing proposed changes, e.g.: ```@james-flynn-ie```._

--- a/src/solutions/p3LargestPrimeFactor/main.go
+++ b/src/solutions/p3LargestPrimeFactor/main.go
@@ -7,7 +7,7 @@ import "fmt"
 func main() {
 	numberUnderTest := 600851475143
 	//Keep dividing numberUnderTest by incremental i, until it can't be divided by i any longer.
-	for i := 2; i <= numberUnderTest; i++ {
+	for i := 2; i < numberUnderTest; i++ {
 		if numberUnderTest%i == 0 && numberUnderTest != i {
 			// Divide by factor, before looping again.
 			numberUnderTest = numberUnderTest / i

--- a/src/solutions/p4LargestPalindomeProduct/main.go
+++ b/src/solutions/p4LargestPalindomeProduct/main.go
@@ -5,24 +5,38 @@ import (
 	"strconv"
 )
 
+var (
+	palindromefound   int
+	largestpalindrome int
+)
+
 //A palindromic number reads the same both ways.
 //The largest palindrome made from the product of two 2-digit numbers is 9009 = 91 × 99.
 //Find the largest palindrome made from the product of two 3-digit numbers.
 func main() {
-	for i := 9; i >= 0; i-- {
+	for i := 999; i >= 0; i-- {
 		//j doesn't need to be initialized at 999, because setting it that high would duplicate the previous i values.
 		// i * j  is the same as j * i , e.g.: i (999) * j (996) would be the same as i (996) * j (999).
 		for j := i; j > 0; j-- {
 			numberundertest := i * j
-			fmt.Printf("\n%d * %d = %d", i, j, numberundertest)
 
 			//Convert to a string before reversing.
 			resultstr := strconv.Itoa(numberundertest)
-			fmt.Println("resultstr " + resultstr)
 			reversedstr := reverse(resultstr)
-			fmt.Println("reversedstr " + reversedstr)
+			//fmt.Println("\nreversedstr " + reversedstr)
+
+			if resultstr == reversedstr {
+				palindromefound = numberundertest
+				//Uncomment this line to output the full list of palindromes.
+				//fmt.Printf("\nFound a palindrome! %v == %v", resultstr, reversedstr)
+			}
+
+			if palindromefound > largestpalindrome {
+				largestpalindrome = palindromefound
+			}
 		}
 	}
+	fmt.Printf("The largest palindrome made from the product of two 3-digit numbers is: %d", largestpalindrome)
 }
 
 func reverse(s string) string {
@@ -31,8 +45,8 @@ func reverse(s string) string {
 
 	//Both counters, m and n, start at 0. We increment m upwards through the byte sequence.
 	//We decrement n so that it counts from the last [-1] position in the String towards the start.
-	//We then swap the byte found at m with the byte at n.
-	//Once m becomes equal to n, then we are finished swapping the bytes.
+	//We then swap the byte found at m with the byte at n, and vice versa.
+	//Once the counter m becomes equal to n, then we are finished swapping all of the bytes.
 	for m, n := 0, len(bytes)-1; m < n; m, n = m+1, n-1 {
 		bytes[m], bytes[n] = bytes[n], bytes[m]
 	}

--- a/src/solutions/p4LargestPalindomeProduct/main.go
+++ b/src/solutions/p4LargestPalindomeProduct/main.go
@@ -16,19 +16,18 @@ var (
 func main() {
 	for i := 999; i >= 0; i-- {
 		//j doesn't need to be initialized at 999, because setting it that high would duplicate the previous i values.
-		// i * j  is the same as j * i , e.g.: i (999) * j (996) would be the same as i (996) * j (999).
+		// i * j  is the same as j * i , e.g.: i (997) * j (996) would be the same as i (996) * j (997), so j = 996 would do.
 		for j := i; j > 0; j-- {
 			numberundertest := i * j
 
-			//Convert to a string before reversing.
-			resultstr := strconv.Itoa(numberundertest)
-			reversedstr := reverse(resultstr)
-			//fmt.Println("\nreversedstr " + reversedstr)
+			numstr := strconv.Itoa(numberundertest)
+			reversedstr := reverse(numstr)
 
-			if resultstr == reversedstr {
+			if numstr == reversedstr {
 				palindromefound = numberundertest
+
 				//Uncomment this line to output the full list of palindromes.
-				//fmt.Printf("\nFound a palindrome! %v == %v", resultstr, reversedstr)
+				//fmt.Printf("\nFound a palindrome! %v == %v", numstr, reversedstr)
 			}
 
 			if palindromefound > largestpalindrome {

--- a/src/solutions/p4LargestPalindomeProduct/main.go
+++ b/src/solutions/p4LargestPalindomeProduct/main.go
@@ -1,8 +1,40 @@
 package main
 
+import (
+	"fmt"
+	"strconv"
+)
+
 //A palindromic number reads the same both ways.
 //The largest palindrome made from the product of two 2-digit numbers is 9009 = 91 × 99.
 //Find the largest palindrome made from the product of two 3-digit numbers.
 func main() {
+	for i := 9; i >= 0; i-- {
+		//j doesn't need to be initialized at 999, because setting it that high would duplicate the previous i values.
+		// i * j  is the same as j * i , e.g.: i (999) * j (996) would be the same as i (996) * j (999).
+		for j := i; j > 0; j-- {
+			numberundertest := i * j
+			fmt.Printf("\n%d * %d = %d", i, j, numberundertest)
 
+			//Convert to a string before reversing.
+			resultstr := strconv.Itoa(numberundertest)
+			fmt.Println("resultstr " + resultstr)
+			reversedstr := reverse(resultstr)
+			fmt.Println("reversedstr " + reversedstr)
+		}
+	}
+}
+
+func reverse(s string) string {
+	//UTF-8 String literals are a sequence of bytes, so we can switch them using this type.
+	bytes := []byte(s)
+
+	//Both counters, m and n, start at 0. We increment m upwards through the byte sequence.
+	//We decrement n so that it counts from the last [-1] position in the String towards the start.
+	//We then swap the byte found at m with the byte at n.
+	//Once m becomes equal to n, then we are finished swapping the bytes.
+	for m, n := 0, len(bytes)-1; m < n; m, n = m+1, n-1 {
+		bytes[m], bytes[n] = bytes[n], bytes[m]
+	}
+	return string(bytes)
 }


### PR DESCRIPTION
<!-- Include the issue number after the # tag, e.g.:
    For #1234
-->
For #6 
@james-flynn-ie 

Problem solved:
```A palindromic number reads the same both ways. 
The largest palindrome made from the product of two 2-digit numbers is 9009 = 91 × 99. 
The largest palindrome made from the product of two 2-digit numbers is 9009 = 91 × 99. 
Find the largest palindrome made from the product of two 3-digit numbers. 
Find the largest palindrome made from the product of two 3-digit numbers. 
```

This solution loops through the ints<= 999, multiplying them and checking if the product is a palindrome.

To check if they are a palindrome, we convert the int to a string and then switch the order of bytes so that the first byte becomes the last, and the last byte is moved to the first position.


We then compare the number (converted from int to string) to the reversed number string, and if they match then they are a palindrome.


We then check if the new palindrome is greater than the largest palindrome we have found yet. At the end we output the largest palindrome.
<!--
  When an item is complete, then go ahead and check it off as "done", e.g.:
    - [x] A description of the changes proposed in the pull request.
-->
Please include:
- [x] _A reference to a related issue in your repository._
- [x] _A description of the changes proposed in the pull request._
- [x] _`@mentions of the person or team responsible for reviewing proposed changes, e.g.: ```@james-flynn-ie```._
